### PR TITLE
Add the `noSuccess` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ The most human-friendly [TAP reporter](https://github.com/substack/tape#pretty-r
 
 You can use tap-notify in the same way as other [TAP reporters](https://github.com/substack/tape#pretty-reporters).
 
-```
+```bash
 npm install -g tap-diff
 ```
 
-```
+```bash
 tape ./*.test.js | tap-diff
 ```
 
@@ -32,6 +32,19 @@ test.createStream()
 process.argv.slice(2).forEach(function (file) {
   require(path.resolve(file));
 });
+```
+
+## Options
+
+You can choose to discard success messages using the `--nosuccess` (CLI) or `{noSuccess: true}`:
+
+```bash
+tape ./test.js | tap-diff --nosuccess
+```
+
+```js
+test.createStream({ noSuccess: true })
+  .pipe(tapDiff());
 ```
 
 ## License

--- a/distributions/cli.js
+++ b/distributions/cli.js
@@ -3,11 +3,26 @@
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
+var _yargs = require('yargs');
+
+var _yargs2 = _interopRequireDefault(_yargs);
+
 var _index = require('./index');
 
 var _index2 = _interopRequireDefault(_index);
 
-var reporter = (0, _index2['default'])();
+var usage = '\nUsage: tap-diff [--nosuccess]\n\nOptions:\n  --nosuccess       Discard success messages\n';
+
+var argv = _yargs2['default'].argv;
+
+if (argv.h || argv.help) {
+  console.log(usage);
+  process.exit(0);
+}
+
+var reporter = (0, _index2['default'])({
+  noSuccess: argv.nosuccess
+});
 
 process.stdin.pipe(reporter).pipe(process.stdout);
 

--- a/distributions/index.js
+++ b/distributions/index.js
@@ -37,6 +37,10 @@ var FIG_TICK = _figures2['default'].tick;
 var FIG_CROSS = _figures2['default'].cross;
 
 var createReporter = function createReporter() {
+  var _ref = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+  var noSuccess = _ref.noSuccess;
+
   var output = (0, _through22['default'])();
   var p = (0, _tapParser2['default'])();
   var stream = (0, _duplexer2['default'])(p, output);
@@ -72,10 +76,10 @@ var createReporter = function createReporter() {
   var handleAssertFailure = function handleAssertFailure(assert) {
     var name = assert.name;
     var diag = assert.diag;
-    var writeDiff = function writeDiff(_ref) {
-      var value = _ref.value;
-      var added = _ref.added;
-      var removed = _ref.removed;
+    var writeDiff = function writeDiff(_ref2) {
+      var value = _ref2.value;
+      var added = _ref2.added;
+      var removed = _ref2.removed;
 
       var style = _chalk2['default'].white;
 
@@ -131,7 +135,10 @@ var createReporter = function createReporter() {
   });
 
   p.on('assert', function (assert) {
-    if (assert.ok) return handleAssertSuccess(assert);
+    if (assert.ok) {
+      if (!noSuccess) handleAssertSuccess(assert);
+      return;
+    }
 
     handleAssertFailure(assert);
   });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "figures": "^1.4.0",
     "pretty-ms": "^2.1.0",
     "tap-parser": "^1.2.2",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "yargs": "^3.32.0"
   },
   "devDependencies": {
     "babel": "^5.8.34"

--- a/sources/cli.js
+++ b/sources/cli.js
@@ -1,8 +1,24 @@
 #!/usr/bin/env node
-
+import yargs from 'yargs';
 import createReporter from './index';
 
-const reporter = createReporter();
+const usage = `
+Usage: tap-diff [--nosuccess]
+
+Options:
+  --nosuccess       Discard success messages
+`;
+
+const { argv } = yargs;
+
+if (argv.h || argv.help) {
+  console.log(usage);
+  process.exit(0);
+}
+
+const reporter = createReporter({
+  noSuccess: argv.nosuccess,
+});
 
 process.stdin
   .pipe(reporter)

--- a/sources/index.js
+++ b/sources/index.js
@@ -10,7 +10,7 @@ const INDENT = '  ';
 const FIG_TICK = figures.tick;
 const FIG_CROSS = figures.cross;
 
-const createReporter = () => {
+const createReporter = ({noSuccess} = {}) => {
   const output = through2();
   const p = parser();
   const stream = duplexer(p, output);
@@ -110,7 +110,10 @@ const createReporter = () => {
   });
 
   p.on('assert', (assert) => {
-    if (assert.ok) return handleAssertSuccess(assert);
+    if (assert.ok) {
+      if (!noSuccess) handleAssertSuccess(assert);
+      return;
+    }
 
     handleAssertFailure(assert);
   });


### PR DESCRIPTION
To both CLI (`--nosuccess`) and API (`createStream({noSuccess: true}`)
to allow users to dicards success lines.

It's super useful to be able to discard _useless_ success lines on large
test suites.
